### PR TITLE
Added FMT_HEADER_ONLY macro when `header_only` is true.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -54,6 +54,7 @@ class FmtConan(ConanFile):
     def package_info(self):
         if self.options.header_only:
             self.info.header_only()
+            self.cpp_info.defines = ["FMT_HEADER_ONLY"]
         else:
             self.cpp_info.libs = ["fmt"]
 


### PR DESCRIPTION
A small and quick patch to fix the link errors when using the library with `header_only=True`