### PR TITLE
#212 Fix toolchain support on Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(cmake_wrapper)
+cmake_minimum_required(VERSION 2.8.11)
 
 include(conanbuildinfo.cmake)
-CONAN_BASIC_SETUP()
+conan_basic_setup()
 
 add_subdirectory("source_subfolder")


### PR DESCRIPTION
- When load toolchain cmake file, an error occur because
  there is no minimum version required on cmake wrapper.

Closes https://github.com/bincrafters/community/issues/212